### PR TITLE
Fix editing bug whereby editing and not changing content wouldn't let you save.

### DIFF
--- a/src/components/TODOItem/PendingItem.tsx
+++ b/src/components/TODOItem/PendingItem.tsx
@@ -31,7 +31,7 @@ export const PendingItem: FC<Props> = observer(({
                            defaultValue={todo?.text?.original}
                            autoFocus={true}
                            onChange={(e) => todo?.setText(e?.target?.value, 'updated')}/> :
-                    <span>{todo?.text?.updated || todo?.text?.original}</span>}
+                    <S.TODOTitle>{todo?.text?.original}</S.TODOTitle>}
             </S.TODOContentContainer>
 
             <S.TODOButtonsContainer>

--- a/src/components/TODOItem/styles.ts
+++ b/src/components/TODOItem/styles.ts
@@ -10,6 +10,13 @@ export const TODOContainer = styled.div`
 export const TODOContentContainer = styled.div`
     display: flex;
     justify-content: flex-start;
+    width: 50%;
+`;
+
+export const TODOTitle = styled.span`
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
 `;
 
 export const TODOButtonsContainer = styled.div`

--- a/src/models/TODO/TODO.ts
+++ b/src/models/TODO/TODO.ts
@@ -34,7 +34,7 @@ export default class TODO {
             setCompleted: action,
             setDeleted: action,
         });
-        
+
         this.setText(data?.text ?? '', 'original');
         data?.completed && this.setCompleted();
     }
@@ -80,7 +80,7 @@ export default class TODO {
     }
 
     acceptEdit(): void {
-        this.setText(this.text?.updated, 'original');
+        this.setText(this.text?.updated || this.text?.original, 'original');
         this.setText('', 'updated');
         this.setEditing(false)
     }

--- a/src/models/TODOs/TODOs.ts
+++ b/src/models/TODOs/TODOs.ts
@@ -77,7 +77,9 @@ export default class TODOs {
                 }
             },
             editing: () => {
-                if (!todo?.getText()?.updated) {
+                const text = todo?.getText();
+
+                if (!text?.original && !text?.updated) {
                     this.setToast({
                         show: true,
                         status: 'warning',


### PR DESCRIPTION
**DESCRIPTION**

1. When text flows outside of the container in view mode, we show the overflow as an ellipsis, do it doesn't push the rest of the content out of the TODO item

2. Editing a TODO but not changing the content and accepting should also pass.