### PR TITLE
fixing-notifications-and-update-titles

### DIFF
--- a/src/components/TODOItem/PendingItem.tsx
+++ b/src/components/TODOItem/PendingItem.tsx
@@ -27,9 +27,10 @@ export const PendingItem: FC<Props> = observer(({
         <S.TODOContainer>
             <S.TODOContentContainer>
                 {(todo?.editing || todo?.creating) ?
-                    <Input placeholder="Enter TODO"
+                    <Input placeholder="Enter Title"
                            defaultValue={todo?.text?.original}
                            autoFocus={true}
+                           onFocus={(e) => todo?.setText(e?.target?.value, 'updated')}
                            onChange={(e) => todo?.setText(e?.target?.value, 'updated')}/> :
                     <S.TODOTitle>{todo?.text?.original}</S.TODOTitle>}
             </S.TODOContentContainer>

--- a/src/components/TODOList/PendingList.tsx
+++ b/src/components/TODOList/PendingList.tsx
@@ -22,8 +22,10 @@ export const PendingList: FC<Props> = observer(({todos}) => {
                 description: message,
                 status: status as AlertStatus
             });
+
+            todos.setToastToDefault();
         }
-    }, [show, message, status, toast]);
+    }, [show, message, status, toast, todos]);
 
     return (
         <div>

--- a/src/models/TODO/TODO.ts
+++ b/src/models/TODO/TODO.ts
@@ -80,7 +80,7 @@ export default class TODO {
     }
 
     acceptEdit(): void {
-        this.setText(this.text?.updated || this.text?.original, 'original');
+        this.setText(this.text?.updated, 'original');
         this.setText('', 'updated');
         this.setEditing(false)
     }

--- a/src/models/TODOs/TODOs.test.ts
+++ b/src/models/TODOs/TODOs.test.ts
@@ -146,7 +146,7 @@ describe('TODOs', () => {
                     expect(todos.toast).toEqual({
                         show: true,
                         status: 'warning',
-                        message: 'Please enter a title before accepting.'
+                        message: 'Please enter a title before creating.'
                     });
                 });
             });
@@ -177,6 +177,69 @@ describe('TODOs', () => {
                     todos.handleAccept('some-generated-id-2', 'creating');
 
                     expect(acceptCreateSpy).toHaveBeenCalledTimes(1);
+                });
+            });
+        });
+
+        describe('when updating a TODO', () => {
+            describe('when todo has no text', () => {
+                let getTextSpy: jest.SpyInstance;
+                beforeEach(() => {
+                    getTextSpy = jest.fn();
+
+                    const getTodoMock = (n: number) => ({
+                        id: `some-generated-id-${n}`,
+                        getText: getTextSpy.mockReturnValue({
+                            updated: ''
+                        })
+                    });
+
+                    (TODO as jest.MockedClass<any>).mockImplementationOnce(
+                        () => getTodoMock(1)
+                    ).mockImplementationOnce(() => getTodoMock(2))
+                        .mockImplementationOnce(() => getTodoMock(3))
+                        .mockImplementationOnce(() => getTodoMock(4))
+                });
+
+                it('should set the toast info', () => {
+                    const todos = new TODOs();
+
+                    todos.handleAccept('some-generated-id-4', 'editing');
+
+                    expect(todos.toast).toEqual({
+                        show: true,
+                        status: 'warning',
+                        message: 'Please enter a title before updating.'
+                    });
+                });
+            });
+
+            describe('when todo has text', () => {
+                let acceptEditSpy: jest.SpyInstance;
+                beforeEach(() => {
+                    acceptEditSpy = jest.fn()
+
+                    const getMockedTodo = (n: number) => ({
+                        id: `some-generated-id-${n}`,
+                        getText: jest.fn().mockReturnValue({
+                            updated: `some-text-value`,
+                        }),
+                        acceptEdit: acceptEditSpy
+                    });
+
+                    (TODO as jest.MockedClass<any>).mockImplementationOnce(
+                        () => getMockedTodo(1)
+                    ).mockImplementationOnce(() => getMockedTodo(2))
+                        .mockImplementationOnce(() => getMockedTodo(3))
+                        .mockImplementationOnce(() => getMockedTodo(4))
+                });
+
+                it('should call accept edit', () => {
+                    const todos = new TODOs();
+
+                    todos.handleAccept('some-generated-id-2', 'editing');
+
+                    expect(acceptEditSpy).toHaveBeenCalledTimes(1);
                 });
             });
         });


### PR DESCRIPTION
**DESCRIPTION**

1. Adding onFocus so we do not have a empty updated value when clicking the edit button.

2. Resetting toast back to default, so we can continue showing error message if we need to.

3. Adding more tests for the accept route when editing.